### PR TITLE
Convert RLECore from imperative to functional

### DIFF
--- a/src/RLECore.hs
+++ b/src/RLECore.hs
@@ -1,17 +1,15 @@
 module RLECore (runLengthEncode, runLengthDecode) where
 
 import Data.Char (isNumber)
+import Data.List (group)
 
 data Encoding = Encoding Char Int
 
 runLengthEncode :: String -> String
-runLengthEncode = encodeRunLengths.createRunLengths
+runLengthEncode = encodeRunLengths.encodeRunLengthGroups.group
     where
-        createRunLengths :: String -> [Encoding]
-        createRunLengths [] = []
-        createRunLengths lst@(x:_) = Encoding x (length match) : createRunLengths remaining
-            where
-                (match, remaining) = span (==x) lst
+        encodeRunLengthGroups :: [String] -> [Encoding]
+        encodeRunLengthGroups = map (\g -> Encoding (head g) (length g))
         encodeRunLengths :: [Encoding] -> String
         encodeRunLengths = concatMap (\(Encoding ch ch_count) -> ch : show ch_count)
 


### PR DESCRIPTION
Currently RLECore's encoding/decoding utilities are mocking imperative
for loops by using the "go" helper function which stores all necessary
state and a pseudo iteration count.

Replace the same with more functional style via composition and whole
value functions to better separate concerns and make the code more
declarative.