### PR TITLE
Support compression of complete ascii character set

### DIFF
--- a/executables/RLEMain.hs
+++ b/executables/RLEMain.hs
@@ -3,7 +3,6 @@ module Main where
 import FileIO
 import RLECore
 import Options.Applicative
-import Data.Semigroup ((<>))
 import Data.List.Extra
 
 data Args = Args

--- a/test/Test/RLECore.hs
+++ b/test/Test/RLECore.hs
@@ -11,5 +11,5 @@ import qualified Hedgehog.Gen as Gen
 rlecore :: Spec
 rlecore = describe "RLECoreTest" $ do
     it "compress + decompress == original" $ hedgehog $ do
-        xs <- forAll $ Gen.string (Range.linear 0 1000) Gen.alpha 
+        xs <- forAll $ Gen.string (Range.linear 0 1000) Gen.ascii 
         (runLengthDecode.runLengthEncode) xs === xs


### PR DESCRIPTION
- Rename `Encoding` to the more appropriate `RunLength` which is what
the data class was being used to represent. Accordingly rename functions
as well.

- Modify the original RLE algorithm to work with the complete ascii
character set. This is done by splitting long run lengths such that each
has the maximum size of 256. In this manner each pair of characters in
the compressed output represents (char, char_count).